### PR TITLE
Better scheduler locking

### DIFF
--- a/kernel/include/atomics.h
+++ b/kernel/include/atomics.h
@@ -43,7 +43,8 @@ typedef struct {
     uint64_t __atomic;
 } atomic_uint64_t;
 
-#define ATOMIC_INIT() {.__atomic = 0}
+#define ATOMIC_INIT_VAL(n) {.__atomic = (n)}
+#define ATOMIC_INIT()      ATOMIC_INIT_VAL(0)
 
 /* Atomically loads value */
 #define atomic_load(atomic_ptr) __atomic_load_n(&(atomic_ptr)->__atomic, __ATOMIC_SEQ_CST)
@@ -92,13 +93,13 @@ typedef struct {
 
 /* Checks if the atomic contains the expected value, if true val is written to the atomic, if false,
  * the value of the atomic is read into expected. Returns weather or not it succeeded */
-#define atomic_compare_exchange(atomic_ptr, expected_ptr, val)                           \
-    ({                                                                                   \
-        /* Type check expected and val */                                                \
-        typeof((*atomic_ptr).__atomic) *__expected = (expected_ptr);                     \
-        typeof((*atomic_ptr).__atomic)  __val      = (val);                              \
+#define atomic_compare_exchange(atomic_ptr, expected_ptr, val)                         \
+    ({                                                                                 \
+        /* Type check expected and val */                                              \
+        typeof((*atomic_ptr).__atomic) *__expected = (expected_ptr);                   \
+        typeof((*atomic_ptr).__atomic)  __val      = (val);                            \
         __atomic_compare_exchange_n(&(atomic_ptr)->__atomic, __expected, __val, false, \
-                                      __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);               \
+                                    __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);               \
     })
 
 /*

--- a/kernel/include/tasks/locking.h
+++ b/kernel/include/tasks/locking.h
@@ -20,6 +20,9 @@
 /* Initialise a staticly allocated mutex */
 #define MUTEX_DEFINE(name) mutex_t name = MUTEX_INIT(name)
 
+#define SPINLOCK_INIT()       {.flag = 0}
+#define SPINLOCK_DEFINE(name) struct spinlock name = SPINLOCK_INIT()
+
 /* Semaphore lock */
 typedef struct semaphore semaphore_t;
 
@@ -35,6 +38,16 @@ typedef struct mutex mutex_t;
 
 struct mutex {
     semaphore_t sem;  // internal implemented as a semaphore of count 1
+};
+
+/*
+ * Classic spinlock, ensures mutual exclusion and non-preemption, works in both
+ * irq and thread context.
+ *
+ * To be used for protecting critical, but fast, sections.
+ */
+struct spinlock {
+    unsigned int flag;
 };
 
 /* Allocate and initialise a semaphore */
@@ -54,5 +67,11 @@ void mutex_lock(mutex_t *mutex);
 
 /* Unlock mutex */
 void mutex_unlock(mutex_t *mutex);
+
+/* Lock spinlock */
+void spinlock_lock(struct spinlock *spinlock, uint32_t *irqflags);
+
+/* Unlock spinlock */
+void spinlock_unlock(struct spinlock *spinlock, uint32_t irqflags);
 
 #endif /* TASK_LOCKING_H */

--- a/kernel/include/tasks/locking.h
+++ b/kernel/include/tasks/locking.h
@@ -20,9 +20,6 @@
 /* Initialise a staticly allocated mutex */
 #define MUTEX_DEFINE(name) mutex_t name = MUTEX_INIT(name)
 
-#define SPINLOCK_INIT()       {.flag = 0}
-#define SPINLOCK_DEFINE(name) struct spinlock name = SPINLOCK_INIT()
-
 /* Semaphore lock */
 typedef struct semaphore semaphore_t;
 
@@ -38,16 +35,6 @@ typedef struct mutex mutex_t;
 
 struct mutex {
     semaphore_t sem;  // internal implemented as a semaphore of count 1
-};
-
-/*
- * Classic spinlock, ensures mutual exclusion and non-preemption, works in both
- * irq and thread context.
- *
- * To be used for protecting critical, but fast, sections.
- */
-struct spinlock {
-    unsigned int flag;
 };
 
 /* Allocate and initialise a semaphore */
@@ -67,11 +54,5 @@ void mutex_lock(mutex_t *mutex);
 
 /* Unlock mutex */
 void mutex_unlock(mutex_t *mutex);
-
-/* Lock spinlock */
-void spinlock_lock(struct spinlock *spinlock, uint32_t *irqflags);
-
-/* Unlock spinlock */
-void spinlock_unlock(struct spinlock *spinlock, uint32_t irqflags);
 
 #endif /* TASK_LOCKING_H */

--- a/kernel/include/tasks/spinlock.h
+++ b/kernel/include/tasks/spinlock.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+
+   See README.md and LICENSE.txt for license details.
+
+   Copyright (C) 2024 Isak Evaldsson
+*/
+#ifndef TASK_SPINLOCK_H
+#define TASK_SPINLOCK_H
+
+#define SPINLOCK_INIT()       {.flag = 0}
+#define SPINLOCK_DEFINE(name) struct spinlock name = SPINLOCK_INIT()
+
+/*
+ * Classic spinlock, ensures mutual exclusion and non-preemption, works in both
+ * irq and thread context.
+ *
+ * To be used for protecting critical, but fast, sections.
+ */
+struct spinlock {
+    unsigned int flag;
+};
+
+/* Lock spinlock */
+void spinlock_lock(struct spinlock *spinlock, uint32_t *irqflags);
+
+/* Unlock spinlock */
+void spinlock_unlock(struct spinlock *spinlock, uint32_t irqflags);
+
+#endif /* TASK_SPINLOCK_H */

--- a/kernel/include/tasks/task_queue.h
+++ b/kernel/include/tasks/task_queue.h
@@ -7,16 +7,17 @@
 #ifndef TASK_TASK_QUEUE_H
 #define TASK_TASK_QUEUE_H
 #include <list.h>
+#include <tasks/spinlock.h>
 #include <tasks/task.h>
 
 /* A generic task queue, with an API to ensure that task are safely queued. To simply scheduling, a
  * task can only be in one queue at the time. */
 typedef struct task_queue {
-    // TODO: Add lock
-    struct list list;
+    struct spinlock lock;
+    struct list     list;
 } task_queue_t;
 
-#define QUEUE_INIT(name) {.list = LIST_INIT((name).list)}
+#define QUEUE_INIT(name) {.lock = SPINLOCK_INIT(), .list = LIST_INIT((name).list)}
 
 /* Initialise an empty task queue */
 #define EMPTY_QUEUE(name) task_queue_t name = QUEUE_INIT(name)

--- a/kernel/tasks/internal.h
+++ b/kernel/tasks/internal.h
@@ -22,6 +22,12 @@ void free_task(task_t *task);
 /* Function handling creation of the root task */
 task_t *create_root_task();
 
+/* Disables preemption within the scheduler */
+void scheduler_disable_preemption();
+
+/* Enabled preemption within the scheduler */
+void scheduler_enable_preemption();
+
 /* Marks the start of a critical section. All code between begin and end will run uninterrupted
  * by preemption or calls to schedule */
 void critical_section_start(uint32_t *interrupt_flags);

--- a/kernel/tasks/internal.h
+++ b/kernel/tasks/internal.h
@@ -28,14 +28,6 @@ void scheduler_disable_preemption();
 /* Enabled preemption within the scheduler */
 void scheduler_enable_preemption();
 
-/* Marks the start of a critical section. All code between begin and end will run uninterrupted
- * by preemption or calls to schedule */
-void critical_section_start(uint32_t *interrupt_flags);
-
-/* Marks the end of a critical section. All code between begin and end will run uninterrupted
- * by preemption or calls to schedule */
-void critical_section_end(uint32_t interrupt_flags);
-
 // The caller is responsible for appropriately locking/unlocking the scheduler when calling it
 void schedule();
 

--- a/kernel/tasks/scheduler.c
+++ b/kernel/tasks/scheduler.c
@@ -171,36 +171,6 @@ void scheduler_unlock(uint32_t interrupt_flags)
 #endif
 }
 
-// Marks the start of a critical region, during it's execution we can't perform task switches nor
-// interrupts
-void critical_section_start(uint32_t *interrupt_flags)
-{
-#ifndef SMP
-    scheduler_lock(interrupt_flags);
-    postpone_task_switch_counter++;
-#endif
-}
-
-// Marks the end of a critical region, during it's execution we can't perform task switches nor
-// interrupts
-void critical_section_end(uint32_t interrupt_flags)
-{
-#ifndef SMP
-    postpone_task_switch_counter--;
-
-    // Are there any more task that require task switching to be postponed
-    if (postpone_task_switch_counter == 0) {
-        // No, do have we have task switches waiting?
-        if (task_switch_postponed) {
-            task_switch_postponed = false;
-            schedule();
-        }
-    }
-
-    scheduler_unlock(interrupt_flags);
-#endif
-}
-
 void scheduler_block_task(unsigned int reason)
 {
     uint32_t flags;

--- a/kernel/tasks/scheduler.c
+++ b/kernel/tasks/scheduler.c
@@ -11,6 +11,7 @@
 #include <memory/vmem_manager.h>
 #include <tasks/locking.h>
 #include <tasks/scheduler.h>
+#include <tasks/spinlock.h>
 #include <tasks/task_queue.h>
 #include <utils.h>
 
@@ -44,6 +45,9 @@ static EMPTY_QUEUE(sleep_queue);
  */
 static DEFINE_LIST(termination_queue);
 
+/* Protects the termination queue */
+static SPINLOCK_DEFINE(termination_lock);
+
 // Counter variables keeping track of the time consumption of each task
 static uint64_t last_count    = 0;
 static uint64_t current_count = 0;
@@ -67,6 +71,9 @@ bool         task_switch_postponed = false;     // Any tries to task switch duri
 /* Variable storing the earliest wakeup time (in ns since boot) for any sleeping task. Allows
  * clock drivers check if it's necessary to call the 'scheduler_check_sleep_queue' */
 uint64_t scheduler_earliest_wakeup = UINT64_MAX;
+
+/* Protects sleep related data */
+static SPINLOCK_DEFINE(sleep_lock);
 
 /* Task responsible of freeing up space for task within the termination queue */
 static task_t *cleanup_task = NULL;
@@ -312,10 +319,13 @@ void schedule()
 static void sleep_expiry_callback(uint64_t time_since_boot_ns, uint64_t timestamp_ns)
 {
     // NOTE: No need to lock scheduler since function will be called within the timer ISR
+
+    uint32_t           flags;
     task_t            *task;
     struct list_entry *entry;
 
     (void)timestamp_ns;  // silence unused warning
+    spinlock_lock(&sleep_lock, &flags);
 
     // Reset first wakeup flag
     scheduler_earliest_wakeup = UINT64_MAX;
@@ -339,6 +349,7 @@ static void sleep_expiry_callback(uint64_t time_since_boot_ns, uint64_t timestam
     if (scheduler_earliest_wakeup < UINT64_MAX) {
         timer_register_timed_event(scheduler_earliest_wakeup, sleep_expiry_callback);
     }
+    spinlock_unlock(&sleep_lock, flags);
 }
 
 /*
@@ -380,15 +391,14 @@ static void preemption_callback(uint64_t time_since_boot_ns, uint64_t timestamp_
 void scheduler_nano_sleep_until(uint64_t when)
 {
     uint32_t flags;
-    critical_section_start(&flags);
     LOG("Put task %x to sleep until %u", current_task, when);
 
     // No need to sleep if when has already occurred
     if (when <= timer_get_time_since_boot()) {
-        critical_section_end(flags);
         return;
     }
 
+    spinlock_lock(&sleep_lock, &flags);
     current_task->sleep_expiry = when;
 
     // Add task to sleep queue
@@ -401,8 +411,7 @@ void scheduler_nano_sleep_until(uint64_t when)
         // Only register time event if this task needs to wakeup before the previous ones
         timer_register_timed_event(when, sleep_expiry_callback);
     }
-
-    critical_section_end(flags);
+    spinlock_unlock(&sleep_lock, flags);
     scheduler_block_task(SLEEPING);
 }
 
@@ -456,10 +465,11 @@ void scheduler_terminate_task()
     // there's none of that yet
 
     uint32_t flags;
-    critical_section_start(&flags);
-
     // Insert task in termination queue
+
+    spinlock_lock(&termination_lock, &flags);
     list_add_last(&termination_queue, &current_task->task_queue_entry);
+    spinlock_unlock(&termination_lock, flags);
 
     // block task, so that a task switch occur once the lock is released
     scheduler_block_task(TERMINATED);
@@ -468,8 +478,6 @@ void scheduler_terminate_task()
     scheduler_unblock_task(cleanup_task);
 
     LOG("Adding %x to termination queue", current_task);
-
-    critical_section_end(flags);
 }
 
 static void cleanup_thread()
@@ -477,13 +485,13 @@ static void cleanup_thread()
     uint32_t           flags;
     task_t            *task;
     struct list_entry *entry;
+    bool               empty;
 
     // TODO: Re-write to handle refcount...
 
     while (true) {
         LOG("wakeup");
-        critical_section_start(&flags);
-
+        spinlock_lock(&termination_lock, &flags);
         LIST_ITER_SAFE_REMOVAL(&termination_queue, entry)
         {
             task = GET_STRUCT(task_t, task_queue_entry, entry);
@@ -498,17 +506,17 @@ static void cleanup_thread()
                 LOG("Terminated thread still in use %x", task);
             }
         }
+        empty = LIST_EMPTY(&termination_queue);
+        spinlock_unlock(&termination_lock, flags);
 
-        if (!LIST_EMPTY(&termination_queue)) {
+        if (!empty) {
             // There tasks left to kill, hopefully they can be free'd the next time this thread
             // runs
-            schedule();
+            scheduler_yield();
         } else {
             // The work is done, but to sleep until there's more work to do
-        scheduler_block_task(PAUSED);
+            scheduler_block_task(PAUSED);
         }
-
-        critical_section_end(flags);
     }
 }
 

--- a/kernel/tasks/task_queue.c
+++ b/kernel/tasks/task_queue.c
@@ -23,36 +23,49 @@ static void prepare_insert(task_queue_t* queue, task_t* task)
 
 void task_queue_enqueue(task_queue_t* queue, task_t* task)
 {
-    // TODO: Lock...
+    uint32_t flags;
+    spinlock_lock(&queue->lock, &flags);
+
     prepare_insert(queue, task);
     list_add_last(&queue->list, &task->task_queue_entry);
+    spinlock_unlock(&queue->lock, flags);
 }
 
 void task_queue_add_first(task_queue_t* queue, task_t* task)
 {
-    // TODO: Lock...
+    uint32_t flags;
+    spinlock_lock(&queue->lock, &flags);
+
     prepare_insert(queue, task);
     list_add_first(&queue->list, &task->task_queue_entry);
+    spinlock_unlock(&queue->lock, flags);
 }
 
 task_t* task_queue_dequeue(task_queue_t* queue)
 {
-    // TODO: Lock...
+    uint32_t flags;
+    spinlock_lock(&queue->lock, &flags);
     struct list_entry* entry = list_remove_first(&queue->list);
     if (!entry) {
+        spinlock_unlock(&queue->lock, flags);
         return NULL;
     }
     task_t* task             = GET_STRUCT(task_t, task_queue_entry, entry);
     task->current_task_queue = NULL;
+    spinlock_unlock(&queue->lock, flags);
     put_task(task);  // Allow task to be free'ed
     return task;
 }
 
 void task_remove_from_current_task_queue(task_t* task)
 {
-    // TODO: Handle locking...
-    kassert(task->current_task_queue != NULL);
+    uint32_t      flags;
+    task_queue_t* queue = task->current_task_queue;
+    kassert(queue != NULL);
+
+    spinlock_lock(&queue->lock, &flags);
     task->current_task_queue = NULL;
     list_entry_remove(&task->task_queue_entry);
+    spinlock_unlock(&queue->lock, flags);
     put_task(task);
 }

--- a/make.sh
+++ b/make.sh
@@ -94,7 +94,7 @@ function config() {
 
 
     # Configure the cross-compiler to use the desired system root.
-    export SYSROOT="$PREFIX/lib/gcc/$TARGET/14.2.0"
+    export SYSROOT="$PREFIX/lib/gcc/$TARGET/15.2.0"
     export CC="$CC --sysroot=$SYSROOT"
 }
 

--- a/toolchain/install-binutils.sh
+++ b/toolchain/install-binutils.sh
@@ -12,9 +12,9 @@ source ./envsetup.sh
 #
 # Script downloading, building and installing binutils for cross compilation
 #
-BINUTILS_VERSION="2.44"
+BINUTILS_VERSION="2.45"
 BINUTILS_NAME="binutils-$BINUTILS_VERSION"
-DOWNLOAD_URL="https://ftp.gnu.org/gnu/binutils/binutils-2.44.tar.gz"
+DOWNLOAD_URL="https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.gz"
 SUB_DIR="binutils"
 SRC_DIR="$TMP_DIR/$SUB_DIR/$BINUTILS_NAME"
 OBJ_DIR="$TMP_DIR/$SUB_DIR/objects"

--- a/toolchain/install-gcc.sh
+++ b/toolchain/install-gcc.sh
@@ -12,7 +12,7 @@ source ./envsetup.sh
 #
 # Script downloading, building and installing gcc cross compiler
 #
-GCC_VERSION="14.2.0"
+GCC_VERSION="15.2.0"
 GCC_NAME="gcc-$GCC_VERSION"
 DOWNLOAD_URL="https://ftp.gnu.org/gnu/gcc/$GCC_NAME/$GCC_NAME.tar.gz"
 SUB_DIR="gcc"


### PR DESCRIPTION
Better locking within the scheduler:
- Implementing UMP spin-locks
- Replaces calls to critical section API:s to spinlocks within the scheduler
- Re-write semaphores with atomics